### PR TITLE
Add button and functionalites to remove an organisation from favourites

### DIFF
--- a/app/favourites.py
+++ b/app/favourites.py
@@ -59,3 +59,28 @@ def add_to_favourites():
         message = "success"
 
     return jsonify(message)
+
+
+@favourites.route("/remove_from_favourites", methods=["GET", "POST"])
+@login_required
+def remove_from_favourites():
+    """
+    Function to remove a company from a user's favourite
+    - requires user to be logged-in
+    - Post request received from script.js / my_favourites.html
+    - Retrieve the company ID from the data and removes it from array
+      "favourites"
+    - Return success message
+    """
+    # Retrieve company id from post request
+    resp = request.form.to_dict(flat=False)
+    company_id = resp["companyId"][0]
+    # Retrieve user in session
+    user = User.find_one_user(session["_user_id"].lower())
+    if "favourites" in user:
+        User.remove_from_favourites(user['_id'], company_id)
+        message = "success"
+        return jsonify(message)
+    else:
+        flash("This organisation was not in your favourites")
+        return redirect(url_for('favourites.view_favourites'))

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -91,3 +91,13 @@ class User(UserMixin):
                                       {"$set": {
                                           "favourites": [ObjectId(company_id)]}
                                        })
+
+    @staticmethod
+    def remove_from_favourites(user_id, company_id):
+        """
+        Remove from a company from user's favourite array
+        """
+        mongo.db.users.update_one({"_id": ObjectId(user_id)},
+                                  {"$pull": {
+                                        "favourites": ObjectId(company_id)}
+                                   })

--- a/app/static/js/favourites.js
+++ b/app/static/js/favourites.js
@@ -2,16 +2,42 @@
 
 // List of buttons with data action add to favourite
 let addFavourites = document.querySelectorAll("button[data-action='add-favourite']");
+// Lis of buttons with data action to remove from favourite
+let removeFavourites = document.querySelectorAll("button[data-action='remove-favourite']");
 
 // Bind click event to each buttons in addFavourites
 for (var i = 0; i < addFavourites.length; i++) {
   addFavourites[i].addEventListener('click', addToFavourites, false);
 }
 
+// Bind click event to each buttons in removeFavourites
+for (var i = 0; i < removeFavourites.length; i++) {
+  removeFavourites[i].addEventListener('click', removeFromFavourites, false);
+}
+
 // Function to add a company to favourites and reload page to location
 function addToFavourites(e) {
   let organisationId = this.getAttribute('data-company');
   let url = '/favourites/add_to_favourites';
+  fetch(url, {
+    method: 'post',
+    body: `companyId=${organisationId}`,
+    headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+    },
+}).then((response) => {
+    if (response.status == 200){
+      location.reload();
+    }
+}).catch((error) => {
+    console.log(error);
+});
+}
+
+// Function to remove a company to favourites and reload page to location
+function removeFromFavourites(e) {
+  let organisationId = this.getAttribute('data-company');
+  let url = '/favourites/remove_from_favourites';
   fetch(url, {
     method: 'post',
     body: `companyId=${organisationId}`,

--- a/app/templates/favourites/my_favourites.html
+++ b/app/templates/favourites/my_favourites.html
@@ -39,9 +39,27 @@
             <td>{{ organisation.nace_3_label }}</td>
             <td><a href={{ organisation.web_address }}>{{ organisation.web_address }}</a></td>
             <td>
-                <!-- to include remove from favourite action -->
+                <button class="btn btn-outline-dark" data-bs-toggle="modal" data-bs-target="#remove-{{organisation._id}}" title="Remove from favourite">
+                    <i class="bi bi-x-circle" aria-hidden="true"></i>
+                    <span class="visually-hidden">Remove from favourite</span>
+                </button>
             </td>
         </tr>
+        <!-- modal confirmation -->
+        <div class="modal fade" id="remove-{{organisation._id}}" tabindex="-1" aria-labelledby="remove-from-favourite-confirmation" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <p class="modal-title" id="exampleModalLabel">Are you sure to remove {{organisation.organisation_name}} from your favourites?</p>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" data-action="remove-favourite" data-company="{{organisation._id}}" class="btn btn-primary">Confirm</button>
+                    </div>
+                </div>
+            </div>
+        </div>
         {% endfor %}
     </tbody>
 </table>
@@ -51,4 +69,9 @@
     <a href="{{ url_for('organisations.get_organisations') }}" class="btn btn-primary">View organisations</a>
 {% endif %}
 
+{% endblock %}
+
+{% block scripts %}
+<!-- block script for favourites scripts -->
+<script src="{{ url_for('static', filename='js/favourites.js')}}"></script>
 {% endblock %}


### PR DESCRIPTION
# Business Analysis 🟠 Code Institute 🟠 Community Project - Pull Request 🎉🎉

## Pull Request References:
 - #8

## PR contains:
- INFO ABOUT YOUR PULL REQUEST GOES HERE _(Please be as descriptive as possible)_ 🤜
  - Add button to favourites.html to trigger modal confirmation to delete company from favorite
  - Add modal with data-action "remove-from-favourite" and "data-organisation" to fetch id of the organisation
  - Add and bind event to remove company from user's favourite using ajax call 
  - Update User model with static method to pull company id from favourites id
  - Add function to favourites.py for logic to remove company from user's favourite (function being called in favourites.js)
 
- DETAIL INFORMATION ABOUT THE WORKS DONE TO SATISFY THE TASK/FEATURE/ISSUE.
  - When user clicks on button remove, a modal is displayed asking the user to confirm where they want to remove the company from their favourites.
  - When the user click close or outside the window the modal closes
  - When the user click confirm, the company is removed from their favourites and the page is refreshed
  - The company being removed from favourites is no longer displayed on my favourites page


## Breaking changes
- None

## Screenshots/Gifs/Media

https://user-images.githubusercontent.com/74382632/161047882-043b6c94-0500-4f56-b06f-04c61eaf4811.mov


